### PR TITLE
feat: transactional emails via Resend (admin notices + approval confirmations)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,10 @@ import { handleAdmin } from "./routes/admin";
 export interface Env {
   ASSETS: Fetcher;
   DB: D1Database;
+  ADMIN_EMAIL: string;
+  FROM_EMAIL: string;
+  SITE_URL: string;
+  RESEND_API_KEY?: string;
 }
 
 const CORS_HEADERS: Record<string, string> = {
@@ -48,19 +52,19 @@ export default {
         let response: Response;
 
         if (url.pathname.startsWith("/api/admin/")) {
-          response = await handleAdmin(request, env);
+          response = await handleAdmin(request, env, ctx);
           return withCors(response);
         }
 
         switch (url.pathname) {
           case "/api/register":
-            response = await handleRegister(request, env);
+            response = await handleRegister(request, env, ctx);
             break;
           case "/api/members":
             response = await handleMembers(request);
             break;
           case "/api/initiatives":
-            response = await handleInitiatives(request, env);
+            response = await handleInitiatives(request, env, ctx);
             break;
           case "/api/events":
             response = await handleEvents(request);

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -1,0 +1,141 @@
+interface ApplicationData {
+  id: number;
+  nombre: string;
+  email: string;
+  whatsapp: string;
+  linkedin: string;
+  github?: string | null;
+  origen?: string | null;
+  expertise?: string | null;
+  motivacion: string;
+  referred_by?: string | null;
+}
+
+interface InitiativeData {
+  id: number;
+  title: string;
+  tagline: string;
+  description: string;
+  track: string;
+  proposer_name: string;
+  proposer_email: string;
+  website_url?: string | null;
+  looking_for?: string | null;
+  public_contact?: string | null;
+  launched_at?: string | null;
+}
+
+interface RenderedEmail {
+  subject: string;
+  text: string;
+}
+
+const SIGNATURE = "— Comité de Dysrupción";
+
+function line(label: string, value: string | null | undefined): string {
+  if (!value) return "";
+  return `${label}: ${value}\n`;
+}
+
+export function adminNewApplication(siteUrl: string, app: ApplicationData): RenderedEmail {
+  return {
+    subject: `Nueva solicitud de ingreso — ${app.nombre}`,
+    text:
+`Llegó una solicitud nueva para entrar a Dysrupción.
+
+${line("Nombre", app.nombre)}${line("Email", app.email)}${line("WhatsApp", app.whatsapp)}${line("LinkedIn", app.linkedin)}${line("GitHub", app.github)}${line("Origen", app.origen)}${line("Rol", app.expertise)}${line("Referido por", app.referred_by)}
+Motivación:
+${app.motivacion}
+
+Revísala en el panel:
+${siteUrl}/admin/
+
+${SIGNATURE}
+`,
+  };
+}
+
+export function adminNewInitiative(siteUrl: string, ini: InitiativeData): RenderedEmail {
+  return {
+    subject: `Nueva iniciativa propuesta — ${ini.title}`,
+    text:
+`${ini.proposer_name} propuso una iniciativa nueva para publicar.
+
+${line("Título", ini.title)}${line("Tagline", ini.tagline)}${line("Track", ini.track)}${line("Website", ini.website_url)}${line("Contacto", ini.proposer_email)}${line("Buscan", ini.looking_for)}${line("Contacto público", ini.public_contact)}${line("Lanzamiento", ini.launched_at)}
+Descripción:
+${ini.description}
+
+Revísala en el panel:
+${siteUrl}/admin/
+
+${SIGNATURE}
+`,
+  };
+}
+
+export function applicationApproved(siteUrl: string, app: ApplicationData): RenderedEmail {
+  return {
+    subject: "Bienvenidx a Dysrupción",
+    text:
+`Hola ${app.nombre},
+
+Tu solicitud de ingreso a Dysrupción fue aprobada.
+
+El comité te va a contactar pronto con los detalles para sumarte al chat y a las iniciativas en curso.
+
+Estamos construyendo un espacio donde participar no es opcional: se construye, se propone, se actúa. Te esperamos ahí.
+
+Mientras tanto, dale una vuelta al protocolo y al directorio de iniciativas:
+${siteUrl}/playbook
+${siteUrl}/iniciativas
+
+${SIGNATURE}
+`,
+  };
+}
+
+export function applicationRejected(_siteUrl: string, app: ApplicationData): RenderedEmail {
+  return {
+    subject: "Sobre tu solicitud a Dysrupción",
+    text:
+`Hola ${app.nombre},
+
+Gracias por tu interés en Dysrupción. Después de revisar tu solicitud, decidimos no avanzar con ella en este momento.
+
+Esto no es definitivo. La comunidad cambia, y los criterios también. Si más adelante sientes que el contexto es distinto, puedes volver a aplicar.
+
+${SIGNATURE}
+`,
+  };
+}
+
+export function initiativeApproved(siteUrl: string, ini: InitiativeData): RenderedEmail {
+  return {
+    subject: `Tu iniciativa "${ini.title}" ya está publicada`,
+    text:
+`Hola ${ini.proposer_name},
+
+Aprobamos la iniciativa "${ini.title}" y ya está publicada en el directorio:
+${siteUrl}/iniciativas
+
+Si necesitas editar algo o actualizar el contacto público, responde este correo y lo arreglamos.
+
+${SIGNATURE}
+`,
+  };
+}
+
+export function initiativeRejected(_siteUrl: string, ini: InitiativeData): RenderedEmail {
+  return {
+    subject: `Sobre tu iniciativa "${ini.title}"`,
+    text:
+`Hola ${ini.proposer_name},
+
+Recibimos tu propuesta de "${ini.title}" y decidimos no publicarla en el directorio en este momento.
+
+Si quieres conversar sobre los motivos, o hacer ajustes y volver a enviar, responde este correo.
+
+${SIGNATURE}
+`,
+  };
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,40 @@
+import type { Env } from "../index";
+
+interface SendEmailInput {
+  to: string;
+  subject: string;
+  text: string;
+  html?: string;
+  replyTo?: string;
+}
+
+export async function sendEmail(env: Env, input: SendEmailInput): Promise<void> {
+  if (!env.RESEND_API_KEY) {
+    console.warn("[email] RESEND_API_KEY not configured; skipping send to", input.to);
+    return;
+  }
+
+  const payload: Record<string, unknown> = {
+    from: env.FROM_EMAIL,
+    to: input.to,
+    subject: input.subject,
+    text: input.text,
+  };
+  if (input.html) payload.html = input.html;
+  if (input.replyTo) payload.reply_to = input.replyTo;
+
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    console.error(`[email] Resend ${res.status}: ${body}`);
+    throw new Error(`Resend ${res.status}: ${body}`);
+  }
+}

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,4 +1,11 @@
 import type { Env } from "../index";
+import { sendEmail } from "../lib/email";
+import {
+  applicationApproved,
+  applicationRejected,
+  initiativeApproved,
+  initiativeRejected,
+} from "../lib/email-templates";
 
 interface AdminUser {
   email: string;
@@ -29,7 +36,11 @@ function notFound(): Response {
 const APPLICATION_REVIEW_RE = /^\/api\/admin\/applications\/(\d+)\/(approve|reject)$/;
 const INITIATIVE_REVIEW_RE = /^\/api\/admin\/initiatives\/(\d+)\/(approve|reject)$/;
 
-export async function handleAdmin(request: Request, env: Env): Promise<Response> {
+export async function handleAdmin(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
   const admin = getAdminUser(request);
   if (!admin) return unauthorized();
 
@@ -49,6 +60,7 @@ export async function handleAdmin(request: Request, env: Env): Promise<Response>
   if (method === "POST" && appMatch) {
     return reviewApplication(
       env,
+      ctx,
       Number(appMatch[1]),
       appMatch[2] as "approve" | "reject",
       admin,
@@ -63,6 +75,7 @@ export async function handleAdmin(request: Request, env: Env): Promise<Response>
   if (method === "POST" && initMatch) {
     return reviewInitiative(
       env,
+      ctx,
       Number(initMatch[1]),
       initMatch[2] as "approve" | "reject",
       admin,
@@ -89,11 +102,37 @@ async function listApplications(env: Env, url: URL): Promise<Response> {
 
 async function reviewApplication(
   env: Env,
+  ctx: ExecutionContext,
   id: number,
   action: "approve" | "reject",
   admin: AdminUser,
 ): Promise<Response> {
   const newStatus = action === "approve" ? "approved" : "rejected";
+
+  const row = await env.DB.prepare(
+    `SELECT id, nombre, email, whatsapp, linkedin, github, origen, expertise,
+            motivacion, referred_by, status
+       FROM member_applications WHERE id = ?`,
+  )
+    .bind(id)
+    .first<{
+      id: number;
+      nombre: string;
+      email: string;
+      whatsapp: string;
+      linkedin: string;
+      github: string | null;
+      origen: string | null;
+      expertise: string | null;
+      motivacion: string;
+      referred_by: string | null;
+      status: string;
+    }>();
+
+  if (!row) {
+    return Response.json({ error: "Solicitud no encontrada" }, { status: 404 });
+  }
+
   const result = await env.DB.prepare(
     `UPDATE member_applications
         SET status = ?, reviewed_at = datetime('now'), reviewed_by = ?
@@ -102,9 +141,24 @@ async function reviewApplication(
     .bind(newStatus, admin.email, id)
     .run();
 
-  if (!result.success || result.meta.changes === 0) {
-    return Response.json({ error: "Solicitud no encontrada" }, { status: 404 });
+  if (!result.success) {
+    return Response.json({ error: "No se pudo actualizar la solicitud" }, { status: 500 });
   }
+
+  if (row.status !== newStatus) {
+    const tmpl = action === "approve" ? applicationApproved : applicationRejected;
+    const email = tmpl(env.SITE_URL, row);
+    ctx.waitUntil(
+      sendEmail(env, {
+        to: row.email,
+        subject: email.subject,
+        text: email.text,
+      }).catch((err) =>
+        console.error(`[email] application ${action} notice failed:`, err),
+      ),
+    );
+  }
+
   return Response.json({ ok: true, id, status: newStatus });
 }
 
@@ -125,38 +179,72 @@ async function listInitiatives(env: Env, url: URL): Promise<Response> {
 
 async function reviewInitiative(
   env: Env,
+  ctx: ExecutionContext,
   id: number,
   action: "approve" | "reject",
   admin: AdminUser,
 ): Promise<Response> {
-  if (action === "approve") {
-    const result = await env.DB.prepare(
-      `UPDATE initiatives
-          SET review_status = 'approved',
-              reviewed_at = datetime('now'),
-              reviewed_by = ?,
-              published_at = COALESCE(published_at, datetime('now'))
-        WHERE id = ?`,
-    )
-      .bind(admin.email, id)
-      .run();
-
-    if (!result.success || result.meta.changes === 0) {
-      return Response.json({ error: "Iniciativa no encontrada" }, { status: 404 });
-    }
-    return Response.json({ ok: true, id, review_status: "approved" });
-  }
-
-  const result = await env.DB.prepare(
-    `UPDATE initiatives
-        SET review_status = 'rejected', reviewed_at = datetime('now'), reviewed_by = ?
-      WHERE id = ?`,
+  const row = await env.DB.prepare(
+    `SELECT id, title, tagline, description, track, proposer_name, proposer_email,
+            website_url, looking_for, public_contact, launched_at, review_status
+       FROM initiatives WHERE id = ?`,
   )
-    .bind(admin.email, id)
-    .run();
+    .bind(id)
+    .first<{
+      id: number;
+      title: string;
+      tagline: string;
+      description: string;
+      track: string;
+      proposer_name: string;
+      proposer_email: string;
+      website_url: string | null;
+      looking_for: string | null;
+      public_contact: string | null;
+      launched_at: string | null;
+      review_status: string;
+    }>();
 
-  if (!result.success || result.meta.changes === 0) {
+  if (!row) {
     return Response.json({ error: "Iniciativa no encontrada" }, { status: 404 });
   }
-  return Response.json({ ok: true, id, review_status: "rejected" });
+
+  const newReviewStatus = action === "approve" ? "approved" : "rejected";
+
+  const update =
+    action === "approve"
+      ? env.DB.prepare(
+          `UPDATE initiatives
+              SET review_status = 'approved',
+                  reviewed_at = datetime('now'),
+                  reviewed_by = ?,
+                  published_at = COALESCE(published_at, datetime('now'))
+            WHERE id = ?`,
+        ).bind(admin.email, id)
+      : env.DB.prepare(
+          `UPDATE initiatives
+              SET review_status = 'rejected', reviewed_at = datetime('now'), reviewed_by = ?
+            WHERE id = ?`,
+        ).bind(admin.email, id);
+
+  const result = await update.run();
+  if (!result.success) {
+    return Response.json({ error: "No se pudo actualizar la iniciativa" }, { status: 500 });
+  }
+
+  if (row.review_status !== newReviewStatus) {
+    const tmpl = action === "approve" ? initiativeApproved : initiativeRejected;
+    const email = tmpl(env.SITE_URL, row);
+    ctx.waitUntil(
+      sendEmail(env, {
+        to: row.proposer_email,
+        subject: email.subject,
+        text: email.text,
+      }).catch((err) =>
+        console.error(`[email] initiative ${action} notice failed:`, err),
+      ),
+    );
+  }
+
+  return Response.json({ ok: true, id, review_status: newReviewStatus });
 }

--- a/src/routes/initiatives.ts
+++ b/src/routes/initiatives.ts
@@ -1,4 +1,6 @@
 import type { Env } from "../index";
+import { sendEmail } from "../lib/email";
+import { adminNewInitiative } from "../lib/email-templates";
 
 const TRACKS = [
   "Eventos",
@@ -48,7 +50,11 @@ const REQUIRED_FIELDS: (keyof CreateInitiativeBody)[] = [
   "proposer_email",
 ];
 
-export async function handleInitiatives(request: Request, env: Env): Promise<Response> {
+export async function handleInitiatives(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
   const url = new URL(request.url);
 
   if (request.method === "GET") {
@@ -115,10 +121,33 @@ export async function handleInitiatives(request: Request, env: Env): Promise<Res
         )
         .run();
 
+      const newId = result.meta.last_row_id ?? 0;
+      const email = adminNewInitiative(env.SITE_URL, {
+        id: newId,
+        title: body.title,
+        tagline: body.tagline,
+        description: body.description,
+        track: body.track,
+        proposer_name: body.proposer_name,
+        proposer_email: body.proposer_email,
+        website_url: body.website_url ?? null,
+        looking_for: body.looking_for ?? null,
+        public_contact: body.public_contact ?? null,
+        launched_at: body.launched_at ?? null,
+      });
+      ctx.waitUntil(
+        sendEmail(env, {
+          to: env.ADMIN_EMAIL,
+          subject: email.subject,
+          text: email.text,
+          replyTo: body.proposer_email,
+        }).catch((err) => console.error("[email] admin notice (initiative) failed:", err)),
+      );
+
       return Response.json(
         {
           ok: true,
-          id: result.meta.last_row_id,
+          id: newId,
           message: "Iniciativa recibida. La revisaremos y te avisamos cuando se publique.",
         },
         { status: 201 },

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -1,4 +1,6 @@
 import type { Env } from "../index";
+import { sendEmail } from "../lib/email";
+import { adminNewApplication } from "../lib/email-templates";
 
 interface RegisterBody {
   nombre: string;
@@ -22,7 +24,11 @@ const REQUIRED_FIELDS: (keyof RegisterBody)[] = [
   "motivacion",
 ];
 
-export async function handleRegister(request: Request, env: Env): Promise<Response> {
+export async function handleRegister(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
   if (request.method !== "POST") {
     return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
@@ -70,10 +76,32 @@ export async function handleRegister(request: Request, env: Env): Promise<Respon
       )
       .run();
 
+    const newId = result.meta.last_row_id ?? 0;
+    const email = adminNewApplication(env.SITE_URL, {
+      id: newId,
+      nombre: body.nombre,
+      email: body.email,
+      whatsapp: body.whatsapp,
+      linkedin: body.linkedin,
+      github: body.github ?? null,
+      origen: body.origen ?? null,
+      expertise: body.expertise ?? null,
+      motivacion: body.motivacion,
+      referred_by: body.referred_by ?? null,
+    });
+    ctx.waitUntil(
+      sendEmail(env, {
+        to: env.ADMIN_EMAIL,
+        subject: email.subject,
+        text: email.text,
+        replyTo: body.email,
+      }).catch((err) => console.error("[email] admin notice (application) failed:", err)),
+    );
+
     return Response.json(
       {
         ok: true,
-        id: result.meta.last_row_id,
+        id: newId,
         message: "Solicitud recibida. Te contactaremos pronto.",
       },
       { status: 201 },

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,11 @@ main = "src/index.ts"
 compatibility_date = "2024-12-01"
 account_id = "9d55676c2da03b0899c0d87a00efc8e1"
 
+[vars]
+ADMIN_EMAIL = "beto210391@gmail.com"
+FROM_EMAIL = "Dysrupcion <onboarding@resend.dev>"
+SITE_URL = "https://dysrupcion.dysrupcion.workers.dev"
+
 [assets]
 directory = "./public"
 


### PR DESCRIPTION
## Summary

Tail of the registration/initiatives flow: wires six transactional emails through Resend so the comité gets pinged when something needs review, and applicants/proposers get a real confirmation when the comité decides.

**What sends:**
- Admin notices (to \`ADMIN_EMAIL\`):
  - New member application
  - New initiative submission
- User notices (to the applicant or proposer):
  - Application approved / rejected
  - Initiative approved / rejected

**How it sends:**
- \`src/lib/email.ts\` — thin wrapper around the Resend REST API (\`POST /emails\`, bearer auth).
- \`src/lib/email-templates.ts\` — six plaintext templates, manifesto voice, no HTML for now.
- All sends go through \`ctx.waitUntil(sendEmail(...).catch(console.error))\`. The user response never waits on the SMTP round trip, and Resend failures only log — the registration or admin review succeeds either way.
- State-change check on approve/reject: read current status before the UPDATE, only fire the email when status actually transitions. Repeat clicks no longer spam the user.

**Configuration:**
- \`wrangler.toml [vars]\` (in repo): \`ADMIN_EMAIL=beto210391@gmail.com\`, \`FROM_EMAIL=\"Dysrupcion <onboarding@resend.dev>\"\`, \`SITE_URL=https://dysrupcion.dysrupcion.workers.dev\`
- Secret (not in repo): \`RESEND_API_KEY\` — set via the Cloudflare dashboard (Workers & Pages → dysrupcion → Settings → Variables and Secrets) or \`npx wrangler secret put RESEND_API_KEY\`. Without it, \`sendEmail()\` logs a warning and skips, the rest of the flow still succeeds.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] POST /api/register with no \`RESEND_API_KEY\` set → still returns 201 (verified in prod). Warning logs but does not break the registration.
- [x] After \`RESEND_API_KEY\` is set via dashboard: POST /api/register → admin notice arrives at \`beto210391@gmail.com\` within 30s. (User testing now.)
- [ ] /admin/ approve flow sends confirmation to applicant. Needs Cloudflare Access in front first — pending custom domain.

## Caveats

- \`onboarding@resend.dev\` is the default Resend sender. Until a custom domain is verified in Resend, the only recipient that works is the one the Resend account was registered with. Admin notices to \`beto210391@gmail.com\` will work day one; approval emails to external applicants will fail until a domain is verified. Documented as a follow-up.
- Subject lines pass through template literals (\`Nueva solicitud — \${nombre}\`). Subject injection via newlines is not possible because Resend's REST API handles the SMTP serialization — we send the body as JSON, the headers are framed server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)